### PR TITLE
Fix for Bug #7

### DIFF
--- a/src/js/angular-mega-menu.js
+++ b/src/js/angular-mega-menu.js
@@ -81,7 +81,7 @@
 				var toggleElement = dropdownScope.getToggleElement();
 				var toggleEvent = toggleElement.attr('toggle-event') || 'click';
 
-				if ( !openScope ) {
+				if ( !openScope || openScope !== dropdownScope ) {
 					$document.bind(toggleEvent, closeDropdown);
 					if(toggleEvent !== 'click') $document.bind('click', closeDropdown);
 					$document.bind('keydown', keybindFilter);


### PR DESCRIPTION
updated the `if ( !openScope )` to  `if ( !openScope || openScope !== dropdownScope )` so that if an open scope existed but did not equal the dropdown scope it would still execute.